### PR TITLE
Simple grammar/typo fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <base href="/" />
     <meta charset="UTF-8">
-    <title>Angular1.5 + webpack</title>
+    <title>Angular1.5 + Webpack</title>
 </head>
 <body>
     <ui-view></ui-view>


### PR DESCRIPTION
Main change is to fix the typo in the description, assuming that is possible to fix via pull request. Edit in the `index.html` largely to stop the software believing the two repositories to be indentical (e.g. a semi-hack).